### PR TITLE
Fix sound effect playback

### DIFF
--- a/src/FieldView.cpp
+++ b/src/FieldView.cpp
@@ -278,7 +278,7 @@ FieldView::InvokeTile(const IntPoint &tilePt, uint32 button)
 		else
 		{
 			ClickBox(tilePt);
-			if (gPlaySounds) {
+			if (gPlaySounds && gGameState != GAME_OVER) {
 				delete fPlayer;
 				fPlayer = new BFileGameSound(&fClickSoundRef, false);
 				fPlayer->StartPlaying();

--- a/src/FieldView.cpp
+++ b/src/FieldView.cpp
@@ -4,7 +4,6 @@
 #include <Catalog.h>
 #include <Message.h>
 #include <Path.h>
-#include <PlaySound.h>
 #include <Roster.h>
 #include <stdio.h>
 
@@ -22,7 +21,8 @@ FieldView::FieldView(int32 level)
 		fTracking(false),
 		fFlagCount(0),
 		fMainWin(NULL),
-		fPauseMode(false)
+		fPauseMode(false),
+		fPlayer(NULL)
 {
 	SetDifficulty(level);
 	SetDrawingMode(B_OP_ALPHA);
@@ -39,6 +39,7 @@ FieldView::FieldView(int32 level)
 
 FieldView::~FieldView(void)
 {
+	delete fPlayer;
 }
 
 
@@ -277,8 +278,11 @@ FieldView::InvokeTile(const IntPoint &tilePt, uint32 button)
 		else
 		{
 			ClickBox(tilePt);
-			if (gPlaySounds)
-				play_sound(&fClickSoundRef,true,false,true);
+			if (gPlaySounds) {
+				delete fPlayer;
+				fPlayer = new BFileGameSound(&fClickSoundRef, false);
+				fPlayer->StartPlaying();
+			}
 		}
 	}
 	else if (button == B_SECONDARY_MOUSE_BUTTON)
@@ -607,8 +611,11 @@ FieldView::CheckWin(void)
 void
 FieldView::DoWin(void)
 {
-	if (gPlaySounds)
-		play_sound(&fWinSoundRef,true,false,true);
+	if (gPlaySounds) {
+		delete fPlayer;
+		fPlayer = new BFileGameSound(&fWinSoundRef, false);
+		fPlayer->StartPlaying();
+	}
 	gGameState = -1;
 	fMainWin->SetFace(FACE_WIN);
 	Invalidate();
@@ -617,8 +624,11 @@ FieldView::DoWin(void)
 void
 FieldView::DoLose(void)
 {
-	if (gPlaySounds)
-		play_sound(&fLoseSoundRef,true,false,true);
+	if (gPlaySounds) {
+		delete fPlayer;
+		fPlayer = new BFileGameSound(&fLoseSoundRef, false);
+		fPlayer->StartPlaying();
+	}
 	fMainWin->SetFace(FACE_LOSE);
 	gGameState = -1;
 

--- a/src/FieldView.cpp
+++ b/src/FieldView.cpp
@@ -22,7 +22,9 @@ FieldView::FieldView(int32 level)
 		fFlagCount(0),
 		fMainWin(NULL),
 		fPauseMode(false),
-		fPlayer(NULL)
+		fWinPlayer(NULL),
+		fLosePlayer(NULL),
+		fClickPlayer(NULL)
 {
 	SetDifficulty(level);
 	SetDrawingMode(B_OP_ALPHA);
@@ -39,7 +41,9 @@ FieldView::FieldView(int32 level)
 
 FieldView::~FieldView(void)
 {
-	delete fPlayer;
+	delete fWinPlayer;
+	delete fLosePlayer;
+	delete fClickPlayer;
 }
 
 
@@ -278,11 +282,8 @@ FieldView::InvokeTile(const IntPoint &tilePt, uint32 button)
 		else
 		{
 			ClickBox(tilePt);
-			if (gPlaySounds) {
-				delete fPlayer;
-				fPlayer = new BFileGameSound(&fClickSoundRef, false);
-				fPlayer->StartPlaying();
-			}
+			if (gPlaySounds)
+				fClickPlayer->StartPlaying();
 		}
 	}
 	else if (button == B_SECONDARY_MOUSE_BUTTON)
@@ -611,11 +612,9 @@ FieldView::CheckWin(void)
 void
 FieldView::DoWin(void)
 {
-	if (gPlaySounds) {
-		delete fPlayer;
-		fPlayer = new BFileGameSound(&fWinSoundRef, false);
-		fPlayer->StartPlaying();
-	}
+	if (gPlaySounds)
+		fWinPlayer->StartPlaying();
+
 	gGameState = -1;
 	fMainWin->SetFace(FACE_WIN);
 	Invalidate();
@@ -624,11 +623,9 @@ FieldView::DoWin(void)
 void
 FieldView::DoLose(void)
 {
-	if (gPlaySounds) {
-		delete fPlayer;
-		fPlayer = new BFileGameSound(&fLoseSoundRef, false);
-		fPlayer->StartPlaying();
-	}
+	if (gPlaySounds)
+		fLosePlayer->StartPlaying();
+
 	fMainWin->SetFace(FACE_LOSE);
 	gGameState = -1;
 
@@ -777,16 +774,22 @@ FieldView::SetSoundRefs(void)
 {
 	BPath winpath(fThemePath.String());
 	winpath.Append(gGameStyle->StyleName());
-	winpath.Append("win.ogg");
+	winpath.Append("win.wav");
 	BEntry(winpath.Path()).GetRef(&fWinSoundRef);
+	fWinPlayer = new BFileGameSound(&fWinSoundRef, false);
+	fWinPlayer->Preload();
 
 	BPath losepath(fThemePath.String());
 	losepath.Append(gGameStyle->StyleName());
-	losepath.Append("lose.ogg");
+	losepath.Append("lose.wav");
 	BEntry(losepath.Path()).GetRef(&fLoseSoundRef);
+	fLosePlayer = new BFileGameSound(&fLoseSoundRef, false);
+	fLosePlayer->Preload();
 
 	BPath clickpath(fThemePath.String());
 	clickpath.Append(gGameStyle->StyleName());
-	clickpath.Append("click.ogg");
+	clickpath.Append("click.wav");
 	BEntry(clickpath.Path()).GetRef(&fClickSoundRef);
+	fClickPlayer = new BFileGameSound(&fClickSoundRef, false);
+	fClickPlayer->Preload();
 }

--- a/src/FieldView.h
+++ b/src/FieldView.h
@@ -72,7 +72,10 @@ private:
 	MainWindow	*fMainWin;
 	BString		fThemePath;
 
-	BFileGameSound	*fPlayer;
+	BFileGameSound	*fWinPlayer,
+					*fLosePlayer,
+					*fClickPlayer;
+
 	entry_ref	fWinSoundRef,
 				fLoseSoundRef,
 				fClickSoundRef;

--- a/src/FieldView.h
+++ b/src/FieldView.h
@@ -1,9 +1,11 @@
 #ifndef FIELDVIEW_H
 #define FIELDVIEW_H
 
-#include <View.h>
 #include <Entry.h>
+#include <FileGameSound.h>
 #include <String.h>
+#include <View.h>
+
 #include "Minefield.h"
 
 class GameStyle;
@@ -70,6 +72,7 @@ private:
 	MainWindow	*fMainWin;
 	BString		fThemePath;
 
+	BFileGameSound	*fPlayer;
 	entry_ref	fWinSoundRef,
 				fLoseSoundRef,
 				fClickSoundRef;

--- a/src/Makefile
+++ b/src/Makefile
@@ -71,7 +71,7 @@ RSRCS =
 #	- 	if your library does not follow the standard library naming scheme,
 #		you need to specify the path to the library and it's name.
 #		(e.g. for mylib.a, specify "mylib.a" or "path/mylib.a")
-LIBS =  be localestub media translation $(STDCPPLIBS)
+LIBS =  be game localestub translation $(STDCPPLIBS)
 
 #	Specify additional paths to directories following the standard libXXX.so
 #	or libXXX.a naming scheme. You can specify full paths or paths relative


### PR DESCRIPTION
Use BFileGameSound instead of play_sound.

Currently there are only sounds when playing the "Classic" theme
(click, win, lose) or "Gray" (win, lose).