### PR TITLE
Add 2x scale for high resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+
+# Created by https://www.gitignore.io/api/c++,vim
+
+*.d
+objects*/
+src/objects*/
+src/BeMines
+
+### C++ ###
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+
+### Vim ###
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+

--- a/src/BitmapButton.cpp
+++ b/src/BitmapButton.cpp
@@ -119,7 +119,7 @@ BitmapButton::Draw(BRect update)
 {
 	if (!IsEnabled()) {
 		if (fDisabled)
-			DrawBitmap(fDisabled, BPoint(0,0));
+			DrawBitmap(fDisabled, update);
 		else
 			StrokeRect(Bounds());
 		return;
@@ -128,32 +128,33 @@ BitmapButton::Draw(BRect update)
 	if (Value() == B_CONTROL_ON) {
 		if (IsFocus()) {
 			if (fFocusDown)
-				DrawBitmap(fFocusDown, BPoint(0,0));
+				DrawBitmap(fFocusDown, update);
 			else {
 				if (fDown)
-					DrawBitmap(fUp, BPoint(0,0));
+					DrawBitmap(fUp, update);
 				SetHighColor(ui_color(B_KEYBOARD_NAVIGATION_COLOR));
 				StrokeRect(Bounds());
 			}
 		} else {
 			if (fDown)
-				DrawBitmap(fDown, BPoint(0,0));
+				DrawBitmap(fDown, update);
 			else
 				StrokeRect(Bounds());
 		}
 	} else {
 		if (IsFocus()) {
 			if (fFocusUp)
-				DrawBitmap(fFocusUp, BPoint(0,0));
+				DrawBitmap(fFocusUp, update);
 			else {
 				if (fUp)
-					DrawBitmap(fUp, BPoint(0,0));
+					DrawBitmap(fUp, update);
 				SetHighColor(ui_color(B_KEYBOARD_NAVIGATION_COLOR));
 				StrokeRect(Bounds());
 			}
 		} else {
+
 			if (fUp)
-				DrawBitmap(fUp, BPoint(0,0));
+				DrawBitmap(fUp, update);
 			else
 				StrokeRect(Bounds());
 		}

--- a/src/BitmapButton.h
+++ b/src/BitmapButton.h
@@ -16,7 +16,7 @@
 class BitmapButton : public BButton
 {
 public:
-						BitmapButton(const BRect &frame, const char *name, BBitmap *up, 
+						BitmapButton(const BRect &frame, const char *name, BBitmap *up,
 									BBitmap *down, BMessage *msg, bool own = true,
 									const int32 &resize = B_FOLLOW_LEFT | B_FOLLOW_TOP,
 									const int32 &flags = B_WILL_DRAW | B_NAVIGABLE);

--- a/src/CounterView.cpp
+++ b/src/CounterView.cpp
@@ -1,6 +1,7 @@
 #include "CounterView.h"
 #include "GameStyle.h"
 #include <stdio.h>
+#include "Globals.h"
 
 CounterView::CounterView(void)
 	:	BView(BRect(0,0,1,1),"counterview",B_FOLLOW_NONE, B_WILL_DRAW),
@@ -11,7 +12,7 @@ CounterView::CounterView(void)
 		debugger("BUG: empty counter theme");
 
 	BBitmap *zero = fBitmaps[0];
-	ResizeTo(zero->Bounds().Width() * 3,zero->Bounds().Height());
+	ResizeTo(zero->Bounds().Width() * 3 * gScale,zero->Bounds().Height() * gScale);
 }
 
 
@@ -40,11 +41,15 @@ CounterView::Draw(BRect update)
 	sprintf(countstr,"%.3d",fCount);
 
 	BPoint pt(0,0);
-	DrawBitmap(fBitmaps[countstr[0] - 48],pt);
-	pt.x += fBitmaps[0]->Bounds().Width();
-	DrawBitmap(fBitmaps[countstr[1] - 48],pt);
+	BRect rect(pt.x,pt.y,pt.x + fBitmaps[0]->Bounds().Width() * gScale,
+		fBitmaps[0]->Bounds().Height() * gScale);
+	DrawBitmap(fBitmaps[countstr[0] - 48], rect);
+	pt.x += fBitmaps[0]->Bounds().Width() * gScale;
+	rect.OffsetTo(pt);
+	DrawBitmap(fBitmaps[countstr[1] - 48],rect);
 	pt.x += pt.x;
-	DrawBitmap(fBitmaps[countstr[2] - 48],pt);
+	rect.OffsetTo(pt);
+	DrawBitmap(fBitmaps[countstr[2] - 48],rect);
 }
 
 
@@ -53,6 +58,6 @@ CounterView::StyleChanged(void)
 {
 	fBitmaps = gGameStyle->LEDSprites();
 	BBitmap *zero = fBitmaps[0];
-	ResizeTo(zero->Bounds().Width() * 3,zero->Bounds().Height());
+	ResizeTo(zero->Bounds().Width() * 3 * gScale,zero->Bounds().Height() * gScale);
 	Invalidate();
 }

--- a/src/GameStyle.cpp
+++ b/src/GameStyle.cpp
@@ -7,6 +7,7 @@
 #include <Roster.h>
 #include <String.h>
 #include <TranslatorFormats.h>
+#include "Globals.h"
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "GameStyle"
@@ -144,7 +145,9 @@ GameStyle::StyleName(void)
 BRect
 GameStyle::TileSize(void)
 {
-	return fBoxSprite->Bounds();
+	BRect r = fBoxSprite->Bounds();
+	r.Set(0,0,r.Width() * gScale, r.Height() * gScale);
+	return r;
 }
 
 

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -6,6 +6,7 @@
 
 bool gCheatMode = false;
 bool gPlaySounds = true;
+uint16 gScale = 1;
 
 BString gThemeName = "Default";
 int32 gDifficulty = DIFFICULTY_BEGINNER;

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -44,6 +44,7 @@ public:
 
 extern bool gCheatMode;
 extern bool gPlaySounds;
+extern uint16 gScale;
 extern BString gThemeName;
 extern int32 gDifficulty;
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -45,6 +45,7 @@ private:
 	void	ResetLayout(void);
 	void	LoadSettings(void);
 	void	SaveSettings(void);
+	bool 	CanScale(void);
 
 	BitmapButton	*fSmileyButton;
 	int8			fSmileyState;

--- a/src/TimerView.cpp
+++ b/src/TimerView.cpp
@@ -2,6 +2,7 @@
 #include <Messenger.h>
 #include <stdio.h>
 #include "GameStyle.h"
+#include "Globals.h"
 
 #define M_INC_TIMER 'inct'
 
@@ -16,7 +17,7 @@ TimerView::TimerView(void)
 		debugger("BUG: empty timer theme");
 
 	BBitmap *zero = fBitmaps[0];
-	ResizeTo(zero->Bounds().Width() * 3,zero->Bounds().Height());
+	ResizeTo(zero->Bounds().Width() * 3 * gScale,zero->Bounds().Height() * gScale);
 }
 
 
@@ -96,11 +97,15 @@ TimerView::Draw(BRect update)
 	sprintf(timestr,"%.3d",fTime);
 
 	BPoint pt(0,0);
-	DrawBitmap(fBitmaps[timestr[0] - 48],pt);
-	pt.x += fBitmaps[0]->Bounds().Width();
-	DrawBitmap(fBitmaps[timestr[1] - 48],pt);
+	BRect rect(pt.x,pt.y,pt.x + fBitmaps[0]->Bounds().Width() * gScale,
+		fBitmaps[0]->Bounds().Height() * gScale);
+	DrawBitmap(fBitmaps[timestr[0] - 48],rect);
+	pt.x += fBitmaps[0]->Bounds().Width() * gScale;
+	rect.OffsetTo(pt);
+	DrawBitmap(fBitmaps[timestr[1] - 48],rect);
 	pt.x += pt.x;
-	DrawBitmap(fBitmaps[timestr[2] - 48],pt);
+	rect.OffsetTo(pt);
+	DrawBitmap(fBitmaps[timestr[2] - 48],rect);
 }
 
 
@@ -109,7 +114,7 @@ TimerView::StyleChanged(void)
 {
 	fBitmaps = gGameStyle->LEDSprites();
 	BBitmap *zero = fBitmaps[0];
-	ResizeTo(zero->Bounds().Width() * 3,zero->Bounds().Height());
+	ResizeTo(zero->Bounds().Width() * 3 * gScale,zero->Bounds().Height() * gScale);
 }
 
 

--- a/src/locales/en.catkeys
+++ b/src/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.dw-BeMines	305506157
+1	English	application/x-vnd.dw-BeMines	697776788
 Sound effects	MainWindow		Sound effects
 Recruit - Win within 100 seconds	AchievementWindow		Recruit - Win within 100 seconds
 Please enter your name.	NewScoreWindow	Second line text new record	Please enter your name.
@@ -6,6 +6,7 @@ Click to resume	FieldWindow		Click to resume
 Be	MainWindow	Theme name	Be
 You have made a new best time!	NewScoreWindow	First line text new record	You have made a new best time!
 OK	ScoreWindow		OK
+OK	MainWindow		OK
 OK	HelpWindow		OK
 Pause	MainWindow		Pause
 Quit	MainWindow		Quit
@@ -27,6 +28,7 @@ The goal of the game is to flag all mines that are hidden on the board. The coun
 Default	MainWindow	Theme name	Default
 High scores	MainWindow		High scores
 Master Defuser - Win within 50 seconds	AchievementWindow		Master Defuser - Win within 50 seconds
+Your current game would not fit your current screen size if scaled.\n\nPlease set the custom board to no more than %d tiles wide and %d tiles high before scaling.	MainWindow		Your current game would not fit your current screen size if scaled.\n\nPlease set the custom board to no more than %d tiles wide and %d tiles high before scaling.
 Difficulty: Intermediate	AchievementWindow		Difficulty: Intermediate
 OK	AchievementWindow		OK
 Active Duty - Win 5 games	AchievementWindow		Active Duty - Win 5 games
@@ -66,6 +68,7 @@ PAUSED	FieldWindow		PAUSED
 Reset	ScoreWindow		Reset
 A themable, open-source rendition of Minesweeper.	MainWindow		A themable, open-source rendition of Minesweeper.
 Difficulty: Beginner	AchievementWindow		Difficulty: Beginner
+Scale 2x	MainWindow		Scale 2x
 Custom…	MainWindow		Custom…
 Achievements	AchievementWindow		Achievements
 Width:	CustomWindow		Width:


### PR DESCRIPTION
This pull request is for issue #42 , adding a 2x scaling option under the "Settings" menu. Activating scaling will double the size of everything, without interrupting the game play. The setting is saved along with other settings when the application is closed. Works with all themes.

Maybe it would be better to have a "Scale" submenu with two options: 1X and 2X?

I'm having trouble scaling the Smiley button, any help appreciated.